### PR TITLE
Added a backward compatibility for `skipTest` method for python 2.6

### DIFF
--- a/src/cygapt/test/case/__init__.py
+++ b/src/cygapt/test/case/__init__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+######################## BEGIN LICENSE BLOCK ########################
+# This file is part of the cygapt package.
+#
+# Copyright (C) 2002-2009 Jan Nieuwenhuizen  <janneke@gnu.org>
+#               2002-2009 Chris Cormie       <cjcormie@gmail.com>
+#                    2012 James Nylen        <jnylen@gmail.com>
+#               2012-2014 Alexandre Quercia  <alquerci@email.com>
+#
+# For the full copyright and license information, please view the
+# LICENSE file that was distributed with this source code.
+######################### END LICENSE BLOCK #########################
+
+from __future__ import absolute_import;
+
+import sys;
+
+if sys.version_info < (3, ):
+    from .py2 import TestCase as BaseTestCase;
+else:
+    from unittest import TestCase as BaseTestCase;
+
+class TestCase(BaseTestCase):
+    """Base class for all cygapt test case.
+    """

--- a/src/cygapt/test/case/exception.py
+++ b/src/cygapt/test/case/exception.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+######################## BEGIN LICENSE BLOCK ########################
+# This file is part of the cygapt package.
+#
+# Copyright (C) 2002-2009 Jan Nieuwenhuizen  <janneke@gnu.org>
+#               2002-2009 Chris Cormie       <cjcormie@gmail.com>
+#                    2012 James Nylen        <jnylen@gmail.com>
+#               2012-2014 Alexandre Quercia  <alquerci@email.com>
+#
+# For the full copyright and license information, please view the
+# LICENSE file that was distributed with this source code.
+######################### END LICENSE BLOCK #########################
+
+from __future__ import absolute_import;
+
+import sys;
+
+if sys.version_info < (3, ):
+    from .py2.exception import SkipTestException as BaseSkipTestException;
+else:
+    from unittest import SkipTest as BaseSkipTestException;
+
+class SkipTestException(BaseSkipTestException):
+    """Raise this exception in a test to skip it.
+    """

--- a/src/cygapt/test/case/py2/__init__.py
+++ b/src/cygapt/test/case/py2/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+######################## BEGIN LICENSE BLOCK ########################
+# This file is part of the cygapt package.
+#
+# Copyright (C) 2002-2009 Jan Nieuwenhuizen  <janneke@gnu.org>
+#               2002-2009 Chris Cormie       <cjcormie@gmail.com>
+#                    2012 James Nylen        <jnylen@gmail.com>
+#               2012-2014 Alexandre Quercia  <alquerci@email.com>
+#
+# For the full copyright and license information, please view the
+# LICENSE file that was distributed with this source code.
+######################### END LICENSE BLOCK #########################
+
+from __future__ import absolute_import;
+
+import sys;
+
+if sys.version_info < (2, 7):
+    from .minor6 import TestCase;
+else:
+    from unittest import TestCase;

--- a/src/cygapt/test/case/py2/exception.py
+++ b/src/cygapt/test/case/py2/exception.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+######################## BEGIN LICENSE BLOCK ########################
+# This file is part of the cygapt package.
+#
+# Copyright (C) 2002-2009 Jan Nieuwenhuizen  <janneke@gnu.org>
+#               2002-2009 Chris Cormie       <cjcormie@gmail.com>
+#                    2012 James Nylen        <jnylen@gmail.com>
+#               2012-2014 Alexandre Quercia  <alquerci@email.com>
+#
+# For the full copyright and license information, please view the
+# LICENSE file that was distributed with this source code.
+######################### END LICENSE BLOCK #########################
+
+from __future__ import absolute_import;
+
+import sys;
+
+if sys.version_info < (2, 7):
+    from .minor6.exception import SkipTestException;
+else:
+    from unittest import SkipTest as SkipTestException;

--- a/src/cygapt/test/case/py2/minor6/__init__.py
+++ b/src/cygapt/test/case/py2/minor6/__init__.py
@@ -1,0 +1,165 @@
+# -*- coding: utf-8 -*-
+######################## BEGIN LICENSE BLOCK ########################
+# This file is part of the cygapt package.
+#
+# Copyright (C) 2002-2009 Jan Nieuwenhuizen  <janneke@gnu.org>
+#               2002-2009 Chris Cormie       <cjcormie@gmail.com>
+#                    2012 James Nylen        <jnylen@gmail.com>
+#               2012-2014 Alexandre Quercia  <alquerci@email.com>
+#
+# For the full copyright and license information, please view the
+# LICENSE file that was distributed with this source code.
+######################### END LICENSE BLOCK #########################
+
+from __future__ import absolute_import;
+
+from unittest import TestCase as BaseTestCase;
+from unittest import _TextTestResult;
+from unittest import TestResult;
+
+from .exception import SkipTestException;
+
+__unittest = True;
+
+class TestCase(BaseTestCase):
+    """Backports some useful feature from newer unittest version.
+    """
+
+    def run(self, result=None):
+        """Runs the test.
+
+        @param result: TestResult
+        """
+        assert None is result or isinstance(result, TestResult);
+
+        if None is result :
+            result = self.defaultTestResult();
+
+        if not isinstance(result, _TestResultWrapper) :
+            result = _TestResultWrapper(result);
+
+        return BaseTestCase.run(self, result);
+
+    def skipTest(self, reason):
+        """Skip this test.
+
+        @param reason: str Explain why this test is skip
+
+        @raise SkipTest: Always
+        """
+        assert isinstance(reason, str);
+
+        raise SkipTestException(reason);
+
+class _AbstractTestResultWrapper(TestResult):
+    """Backports some useful feature from newer unittest version.
+    """
+
+    def __init__(self, result):
+        """Constructor.
+
+        @param result: TestResult The wrapped object
+        """
+        assert isinstance(result, TestResult);
+
+        TestResult.__init__(self);
+
+        self._result = result;
+
+    def startTest(self, test):
+        """Called when the given test is about to be run.
+
+        @param test: TestCase The case where the skip come from
+        """
+        assert isinstance(test, BaseTestCase);
+
+        return self._result.startTest(test);
+
+    def stopTest(self, test):
+        """Called when the given test has been run.
+
+        @param test: TestCase The case where the skip come from
+        """
+        assert isinstance(test, BaseTestCase);
+
+        return self._result.stopTest(test);
+
+    def addError(self, test, err):
+        """Called when an error has occurred.
+
+        @param test: TestCase The case where the error come from
+        @param err:  tuple    Returned by sys.exc_info()
+        """
+        assert isinstance(test, BaseTestCase);
+        assert isinstance(err, tuple);
+
+        return self._result.addError(test, err);
+
+    def addFailure(self, test, err):
+        """Called when a test failed.
+
+        @param test: TestCase The case where the failure come from
+        @param err:  tuple    Returned by sys.exc_info()
+        """
+        assert isinstance(test, BaseTestCase);
+        assert isinstance(err, tuple);
+
+        return self._result.addFailure(test, err);
+
+    def addSuccess(self, test):
+        """Called when a test has completed successfully.
+
+        @param test: TestCase The case where the success come from
+        """
+        assert isinstance(test, BaseTestCase);
+
+        return self._result.addSuccess(test);
+
+    def wasSuccessful(self):
+        """Tells whether or not this result was a success.
+
+        @return: bool
+        """
+        return self._result.wasSuccessful();
+
+    def stop(self):
+        """Indicates that the tests should be aborted.
+        """
+        return self._result.stop();
+
+class _TestResultWrapper(_AbstractTestResultWrapper):
+    """Backports some useful feature from newer unittest version.
+    """
+
+    def addError(self, test, err):
+        """Called when an error has occurred.
+
+        @param test: TestCase The case where the error come from
+        @param err:  tuple    Returned by sys.exc_info()
+        """
+        assert isinstance(test, BaseTestCase);
+        assert isinstance(err, tuple);
+
+        exception = err[1];
+        if isinstance(exception, SkipTestException) :
+            return self._addSkip(test, str(exception));
+
+        return _AbstractTestResultWrapper.addError(self, test, err);
+
+    def _addSkip(self, test, reason):
+        """Called when a test is skipped.
+
+        @param test:   TestCase The case where the skip come from
+        @param reason: str      Explain why a test has been skip
+        """
+        assert isinstance(test, BaseTestCase);
+        assert isinstance(reason, str);
+
+        if not isinstance(self._result, _TextTestResult) :
+            return;
+
+        if self._result.showAll :
+            self._result.stream.writeln("skipped {0!r}".format(reason));
+        elif self._result.dots :
+            self._result.stream.write("s");
+            self._result.stream.flush();

--- a/src/cygapt/test/case/py2/minor6/exception.py
+++ b/src/cygapt/test/case/py2/minor6/exception.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+######################## BEGIN LICENSE BLOCK ########################
+# This file is part of the cygapt package.
+#
+# Copyright (C) 2002-2009 Jan Nieuwenhuizen  <janneke@gnu.org>
+#               2002-2009 Chris Cormie       <cjcormie@gmail.com>
+#                    2012 James Nylen        <jnylen@gmail.com>
+#               2012-2014 Alexandre Quercia  <alquerci@email.com>
+#
+# For the full copyright and license information, please view the
+# LICENSE file that was distributed with this source code.
+######################### END LICENSE BLOCK #########################
+
+from __future__ import absolute_import;
+
+class SkipTestException(Exception):
+    """Raise this exception in a test to skip it.
+    """

--- a/src/cygapt/test/test_argparser.py
+++ b/src/cygapt/test/test_argparser.py
@@ -21,11 +21,12 @@ import unittest;
 import sys;
 import warnings;
 
+from cygapt.test.case import TestCase;
 from cygapt.argparser import CygAptArgParser;
 
-class TestArgParser(unittest.TestCase):
+class TestArgParser(TestCase):
     def setUp(self):
-        unittest.TestCase.setUp(self);
+        TestCase.setUp(self);
         self.obj = CygAptArgParser("usage", "scriptname");
 
         self.__originArgv = sys.argv[:];
@@ -34,7 +35,7 @@ class TestArgParser(unittest.TestCase):
     def tearDown(self):
         sys.argv = self.__originArgv;
 
-        unittest.TestCase.tearDown(self);
+        TestCase.tearDown(self);
 
     def test___init__(self):
         self.assertTrue(isinstance(self.obj, CygAptArgParser));

--- a/src/cygapt/test/test_ob.py
+++ b/src/cygapt/test/test_ob.py
@@ -21,18 +21,19 @@ from __future__ import absolute_import;
 import unittest;
 import sys;
 
+from cygapt.test.case import TestCase;
 from cygapt.ob import CygAptOb;
 
 REPR_STDOUT = repr(sys.stdout);
 
-class TestOb(unittest.TestCase):
+class TestOb(TestCase):
     def setUp(self):
-        unittest.TestCase.setUp(self);
+        TestCase.setUp(self);
         self.obj = CygAptOb(False);
 
     def tearDown(self):
-        unittest.TestCase.tearDown(self);
         self.obj._end();
+        TestCase.tearDown(self);
 
     def makeOn(self):
         txt = "TestOb.makeOn ";

--- a/src/cygapt/test/test_path_mapper.py
+++ b/src/cygapt/test/test_path_mapper.py
@@ -18,11 +18,12 @@ import unittest;
 import sys;
 from tempfile import TemporaryFile;
 
+from cygapt.test.case import TestCase;
 from cygapt.path_mapper import PathMapper;
 
-class TestPathMapper(unittest.TestCase):
+class TestPathMapper(TestCase):
     def setUp(self):
-        unittest.TestCase.setUp(self);
+        TestCase.setUp(self);
         self._var_root = "";
         self._var_cygwin_p = sys.platform.startswith("cygwin");
         self.obj = PathMapper(self._var_root, self._var_cygwin_p);

--- a/src/cygapt/test/test_url_opener.py
+++ b/src/cygapt/test/test_url_opener.py
@@ -19,14 +19,15 @@ import sys;
 from tempfile import TemporaryFile;
 from cStringIO import StringIO;
 
+from cygapt.test.case import TestCase;
 from cygapt.url_opener import CygAptURLopener;
 
-class TestUrlOpener(unittest.TestCase):
+class TestUrlOpener(TestCase):
     """Unit test for cygapt.url_opener
     """
 
     def setUp(self):
-        unittest.TestCase.setUp(self);
+        TestCase.setUp(self);
         self.obj = CygAptURLopener(True);
 
     def test__init__(self):

--- a/src/cygapt/test/utils.py
+++ b/src/cygapt/test/utils.py
@@ -13,7 +13,6 @@
 
 from __future__ import absolute_import;
 
-import unittest;
 import os;
 import tempfile;
 import urllib;
@@ -24,11 +23,14 @@ import subprocess;
 import atexit;
 import time;
 
-class TestCase(unittest.TestCase):
+from cygapt.test.case import TestCase as BaseTestCase;
+
+class TestCase(BaseTestCase):
     __mirrorDir = None;
 
     def setUp(self):
-        unittest.TestCase.setUp(self);
+        BaseTestCase.setUp(self);
+
         self._var_tmpdir = tempfile.mkdtemp();
         self._var_old_cwd = os.getcwd();
         os.chdir(self._var_tmpdir);
@@ -120,7 +122,7 @@ class TestCase(unittest.TestCase):
         self._var_setupIni = SetupIniProvider(self, self._var_arch);
 
     def tearDown(self):
-        unittest.TestCase.tearDown(self);
+        BaseTestCase.tearDown(self);
 
         os.environ = self._var_old_env;
         os.chdir(self._var_old_cwd);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Related tickets | #11 |
| License | GNU GPLv3 |
- [x] Merge #40, #41, #42
- [x] Wait for travis response [... OK](https://travis-ci.org/alquerci/cyg-apt/builds/34092250)
- [x] Revert #40, #41, #42

closes #11
