### PR TITLE
Added USERPROFILE environment variable for Windows for config path lookup

### DIFF
--- a/src/cygapt/main.py
+++ b/src/cygapt/main.py
@@ -112,6 +112,13 @@ class CygAptMain():
             );
             if os.path.exists(home_cyg_apt_rc):
                 main_cyg_apt_rc = home_cyg_apt_rc;
+        elif "USERPROFILE" in os.environ :
+            home_cyg_apt_rc = os.path.join(
+                os.environ['USERPROFILE'],
+                ".{0}".format(self.getAppName())
+            );
+            if os.path.exists(home_cyg_apt_rc) :
+                main_cyg_apt_rc = home_cyg_apt_rc;
 
 
         if main_cyg_apt_rc:


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Related tickets |  |
| License | GNU GPL v3 |

The `HOME` environment variable on Windows is call `HOMEPATH`.
