### PR TITLE
Fixed open_tarfile cleanup on Windows platform

### DIFF
--- a/src/cygapt/utils.py
+++ b/src/cygapt/utils.py
@@ -74,8 +74,9 @@ def open_tarfile(ball):
     if ball_orig != ball:
         tf_close_orig = tf.close;
         def tf_close():
+            retValue = tf_close_orig();
             remove_if_exists(ball);
-            return tf_close_orig();
+            return retValue;
         tf.close = tf_close;
     return tf;
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Related tickets |  |
| License | GNU GPL v3 |

On Windows platform the tar file is not delete on close because
it need to be close before removing the file (resource used).
