### PR TITLE
Fixed the library imports for tests on Windows platform

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -5,8 +5,7 @@ ARGUMENTS =
 ARGUMENTS += -v
 
 sourcetest: FORCE
-	@export PYTHONPATH="$(subst \,,$(SD_SRC)):$(PYTHONPATH)";\
-$(PYTHON) $(TEST_SCRIPT) $(ARGUMENTS)
+	cd $(SD_SRC); $(PYTHON) $(TEST_SCRIPT) $(ARGUMENTS)
 
 installtest: FORCE
 	@$(PYTHON) $(TEST_SCRIPT) $(ARGUMENTS)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Related tickets |  |
| License | GNU GPL v3 |

The `SD_SRC` directory a cygwin path and so not compatible with the
Windows Python executable.

To support running tests on Windows plaform through make.

   $ make test PYTHON=<python executable>

We need an alternative way to add the `SD_SRC` directory into the
Python system path. So we need to change the current working
directory to `SD_SRC`.
