### PR TITLE
Fixed architecture detection test on ci appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -96,6 +96,7 @@ test_script:
     - '%CYG_ROOT%/bin/bash -lc "cd \"$OLDPWD\"; make install"'
     - '%CYG_ROOT%/bin/bash -lc "cd \"$OLDPWD\"; make install PYTHON=\"$PYTHON\""'
     - ps: 'cp $env:CYG_ROOT/home/$env:USERNAME/.cyg-apt -destination $env:HOMEPATH'
+    - '%PYTHON% %CYG_ROOT%/bin/cyg-apt update'
     - '%PYTHON% %CYG_ROOT%/bin/cyg-apt ball cygwin> ball~'
     - ps: 'Get-Content ball~ | set path; cmd /c $env:CYG_ROOT/bin/cygpath -w $path> ball~'
     - ps: 'Get-Content ball~'


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Related tickets |  |
| License | GNU GPLv3 |

The `cyg-apt update` command must be executed with the tested Python.
- [x] Merge #37
- [x] Wait for appveyor response ... [OK](https://ci.appveyor.com/project/alquerci/cyg-apt/build/1.0.102)
- [x] Revert #37
