### PR TITLE
Fixed the argparser test

### DIFF
--- a/src/cygapt/test/test_argparser.py
+++ b/src/cygapt/test/test_argparser.py
@@ -31,8 +31,10 @@ class TestArgParser(unittest.TestCase):
         self.__originArgv = sys.argv[:];
         sys.argv = sys.argv[:1];
 
-        def tearDown(self):
-            sys.argv = self.__originArgv;
+    def tearDown(self):
+        sys.argv = self.__originArgv;
+
+        unittest.TestCase.tearDown(self);
 
     def test___init__(self):
         self.assertTrue(isinstance(self.obj, CygAptArgParser));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Related tickets |  |
| License | GNU GPLv3 |

The tearDown method was not define properly.
