### PR TITLE
Fixed the license abbreviation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ Please follow these guidelines for any contributions:
     | Deprecations?   | [yes|no]
     | Tests pass?     | [yes|no]
     | Related tickets | [comma separated list of tickets related by the PR]
-    | License         | GNU GPL v3
+    | License         | GNU GPLv3
 
     ```
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Related tickets |  |
| License | GNU GPLv3 |

Uses the following pattern `GPLv<version>[+]` specified on the [GNU Coding Standards](https://www.gnu.org/prep/standards/html_node/_002d_002dversion.html#g_t_002d_002dversion).
