### PR TITLE
Added checksum command

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,3 +20,8 @@ News
 
       - `<cachedir>/<mirror>/<arch>/setup.ini`
 
+  * Removed the `md5` command, use `checksum` instead.
+
+* 1.2.0 ()
+
+  * Added `checksum` command.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Usage: cyg-apt [OPTION]... COMMAND [PACKAGE]...
     help     : this help message
     install  : download and install packages with dependencies
     list     : list installed packages
-    md5      : check md5 sum of cached package against database
+    checksum : check digest of cached package against database
     missing  : print missing dependencies for package
     new      : list new (upgradable) packages in distribution
     purge    : uninstall packages and delete from cache

--- a/doc/man.1
+++ b/doc/man.1
@@ -41,6 +41,8 @@ cyg\-apt \- a Cygwin package manager utility \-\- command-line interface
 .PP
 .BR "cyg\-apt md5      " [ \-q ] " " [ \-m " " \fIMIRROR_URL ] " "  [ \-t " (" prev | curr | test )] " " \fIPACKAGE
 .PP
+.BR "cyg\-apt checksum " [ \-q ] " " [ \-m " " \fIMIRROR_URL ] " "  [ \-t " (" prev | curr | test )] " " \fIPACKAGE
+.PP
 .BR "cyg\-apt missing  " [ \-xq ] " " [ \-m " " \fIMIRROR_URL ] " " [ \-t " (" prev | curr | test )] " " \fIPACKAGE
 .PP
 .BR "cyg\-apt new      " [ \-q ] " " [ \-m " " \fIMIRROR_URL ] " " [ \-t " (" prev | curr | test )]
@@ -153,6 +155,12 @@ url shows the URL for a given package's tarball.
 .TP
 .B md5
 md5 checks the md5 checksum of a package in the cache against the expected md5
+given in the setup.ini database.
+.IP
+Deprecated since version 1.2 and will be removed in 2.0, use checksum instead.
+.TP
+.B checksum
+Checks the digest of a package in the cache against the expected digest
 given in the setup.ini database.
 .TP
 .B postinstall

--- a/src/cygapt/argparser.py
+++ b/src/cygapt/argparser.py
@@ -39,6 +39,7 @@ class CygAptArgParser():
             'install',
             'list',
             'md5',
+            'checksum',
             'missing',
             'new',
             'purge',
@@ -184,6 +185,14 @@ class CygAptArgParser():
             warnings.warn(
                 "The option -z, --nopostremove is deprecated since version "
                 "1.1 and will be removed in 2.0.",
+                DeprecationWarning
+            );
+
+        if 'md5' == args.command :
+            args.command = 'checksum';
+            warnings.warn(
+                "The command md5 is deprecated since version 1.2 and will be "
+                "removed in 2.0, use checksum instead.",
                 DeprecationWarning
             );
 

--- a/src/cygapt/cygapt.py
+++ b/src/cygapt/cygapt.py
@@ -356,7 +356,7 @@ class CygApt:
         """download package (only, do not install)"""
         self._doDownload();
         self.ball();
-        self.md5();
+        self.checksum();
 
     def _noPackage(self):
         return "{0} is not on mirror {1} in [{2}].".format(
@@ -559,8 +559,8 @@ class CygApt:
     def _checkMd5(self):
         return self._getUrl()[1] == self.getMd5();
 
-    def md5(self):
-        """check md5 sum of cached package against database"""
+    def checksum(self):
+        """check digest of cached package against database"""
         if not os.path.exists(self.getBall()):
             msg = "{0} not downloaded.".format(self.__pkgName);
             raise PackageCacheException(msg);
@@ -571,7 +571,7 @@ class CygApt:
         print("{0}  {1}".format(actual_md5, ball));
         if actual_md5 != md5:
             raise HashException(
-                "md5sum of cached package doesn't match md5 "
+                "digest of cached package doesn't match digest "
                 "in setup.ini from mirror"
             );
 

--- a/src/cygapt/test/test_argparser.py
+++ b/src/cygapt/test/test_argparser.py
@@ -56,6 +56,9 @@ class TestArgParser(TestCase):
     def testParsePostRemove(self):
         self._assertParseCommand("postremove", ["pkg"]);
 
+    def testParseChecksum(self):
+        self._assertParseCommand("checksum", ["pkg"]);
+
     def testArgumentType(self):
         sys.argv.append("--mirror=http://a.mirror.str");
         sys.argv.append("update");
@@ -94,6 +97,17 @@ class TestArgParser(TestCase):
         );
 
         self.assertTrue(ret.nopostremove);
+
+    def testMd5CommandIsDeprecated(self):
+        sys.argv.append("md5");
+
+        ret = self._assertDeprecatedWarning(
+            "The command md5 is deprecated since version 1.2 and will be "
+            "removed in 2.0, use checksum instead.",
+            self.obj.parse
+        );
+
+        self.assertEqual(ret.command, "checksum");
 
     def _assertParseCommand(self, command, args=None):
         """

--- a/src/cygapt/test/test_setup.py
+++ b/src/cygapt/test/test_setup.py
@@ -364,6 +364,17 @@ class TestSetup(TestCase):
     def testUsageContainPostRemoveCommand(self):
         self._assertUsageContainCommand("postremove");
 
+    def testUsageContainChecksumCommand(self):
+        self._assertUsageContainCommand("checksum");
+
+    def testUsageNotContainMd5Command(self):
+        try:
+            self._assertUsageContainCommand("md5");
+        except self.failureException :
+            pass;
+        else:
+            self.fail("Failed asserting that usage does not contain md5 command.");
+
     def _assertUsageContainCommand(self, command):
         ob = CygAptOb(True);
         self.obj.usage();

--- a/tools/completion.bash
+++ b/tools/completion.bash
@@ -42,7 +42,7 @@ find
 help
 install
 list
-md5
+checksum
 missing
 new
 purge
@@ -113,7 +113,7 @@ ftp://lug.mtu.edu/cygwin/
             fi
 
             case "${COMP_WORDS[1]}" in
-                ball|requires|show|download|md5|purge|search|source|url|filelist|install|missing|remove|version )
+                ball|requires|show|download|checksum|purge|search|source|url|filelist|install|missing|remove|version )
                     _cyg_apt_set_all_packages;
                     COMPREPLY=( $(compgen -W "${_cyg_apt_all_packages}" -- "${cur}") );
                     return 0;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | yes
| Tests pass?     | yes
| Related tickets | #77
| License         | GNU GPLv3

A couple of weeks after the 5 February 2015 Cygwin is going to switch to using SHA512 checksums in the `setup.ini` files. In order to keep consistency the md5 command should be replaced by a more suitable for checks validity of package files. This new command can be called `checksum` or we can find a better name it.