### PR TITLE
Fixed mapping path without ending slash and keep ending path

### DIFF
--- a/src/cygapt/path_mapper.py
+++ b/src/cygapt/path_mapper.py
@@ -67,7 +67,9 @@ class PathMapper:
         # sort to map to /e/bar/foo in pefrence /e/bar
         l = cautils.prsort(list(self.__map.keys()));
         for cygpath in l:
-            if path.find(cygpath) == 0:
-                path = path.replace(cygpath, self.__map[cygpath]);
-                return path;
+            index = path.find(cygpath);
+            if index == 0:
+                return self.__map[cygpath]+path[len(cygpath):];
+            if cygpath.rstrip('/') == path :
+                return self.__map[cygpath].rstrip('/');
         return self.__root + path;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Tests pass?     | yes
| Related tickets | #71
| License         | GNU GPLv3

Fixes path mapping like `/usr/bin` and `/usr/bin/foo/usr/bin/`, when `/usr/bin/` is on the mapping table.