### PR TITLE
Fixed postinstall scripts execution

### DIFF
--- a/src/cygapt/cygapt.py
+++ b/src/cygapt/cygapt.py
@@ -37,6 +37,8 @@ class CygApt:
     DIST_NAMES = ('curr', 'test', 'prev');
     FORCE_BARRED = ["python", "python-argparse", "gnupg", "xz"];
     SH_OPTIONS = " --norc --noprofile ";
+    DASH_OPTIONS = " ";
+    CMD_OPTIONS = " /V:ON /E:ON /C ";
     CYG_POSTINSTALL_DIR = "/etc/postinstall";
     CYG_PREREMOVE_DIR = "/etc/preremove";
     CYG_POSTREMOVE_DIR = "/etc/postremove";
@@ -176,6 +178,12 @@ class CygApt:
 
     def setDosXz(self, dos_xz):
         self.__dosXz = str(dos_xz);
+
+    def getDosDash(self):
+        return self.__dosDash;
+
+    def setDosDash(self, dosDash):
+        self.__dosDash = str(dosDash);
 
     def getPrefixRoot(self):
         return self.__prefixRoot;
@@ -679,7 +687,30 @@ class CygApt:
                     self.SH_OPTIONS,
                     mapped_file
                 ]);
-            retval = os.system(cmd);
+
+            cwd = None;
+            extension = os.path.splitext(mapped_file)[1];
+
+            if ".dash" == extension :
+                cmd = ["dash", self.DASH_OPTIONS, mapped_file];
+                if not self.__cygwinPlatform:
+                    cmd[0] = self.__dosDash;
+                cmd = " ".join(cmd);
+
+            if extension in [".bat", ".cmd"] :
+                cmd = " ".join(["cmd", self.CMD_OPTIONS, os.path.basename(mapped_file)]);
+                cwd = os.path.dirname(mapped_file);
+
+            backupCwd = None;
+            try:
+                if cwd :
+                    backupCwd = os.getcwd();
+                    os.chdir(cwd);
+
+                retval = os.system(cmd);
+            finally:
+                if backupCwd :
+                    os.chdir(backupCwd);
 
             if os.path.exists(mapped_file_done):
                 os.remove(mapped_file_done);
@@ -696,7 +727,11 @@ class CygApt:
         dirname = self.__pm.mapPath(dirname);
 
         if os.path.isdir(dirname):
-            lst = [x for x in os.listdir(dirname) if x[-3:] == ".sh"];
+            lst = list();
+            for filename in os.listdir(dirname) :
+                if os.path.splitext(filename)[1] in ['.sh', '.dash', '.bat', '.cmd'] :
+                    lst.append(filename);
+
             for i in lst:
                 self._runScript("{0}/{1}".format(dirname, i));
 
@@ -1254,6 +1289,7 @@ class CygApt:
         self.__dosBash = "{0}bin/bash".format(self.__pm.getMountRoot());
         self.__dosLn = "{0}bin/ln".format(self.__pm.getMountRoot());
         self.__dosXz = self.__pm.mapPath("/usr/bin/xz");
+        self.__dosDash = "{0}bin/dash".format(self.__pm.getMountRoot());
         return 0;
 
     def _isBarredPackage(self, package):

--- a/src/cygapt/cygapt.py
+++ b/src/cygapt/cygapt.py
@@ -714,7 +714,7 @@ class CygApt:
 
             if os.path.exists(mapped_file_done):
                 os.remove(mapped_file_done);
-            if retval == 0:
+            if retval == 0 and os.path.basename(file_name)[:3] not in ['0p_', 'zp_']:
                 shutil.move(mapped_file, mapped_file_done);
         else:
             if not optional:
@@ -731,6 +731,17 @@ class CygApt:
             for filename in os.listdir(dirname) :
                 if os.path.splitext(filename)[1] in ['.sh', '.dash', '.bat', '.cmd'] :
                     lst.append(filename);
+
+            perpetualScripts = list();
+            regularScripts = list();
+            for filename in lst:
+                if filename[:3] in ['0p_', 'zp_'] :
+                    perpetualScripts.append(filename);
+                else:
+                    regularScripts.append(filename);
+
+            perpetualScripts.sort();
+            lst = perpetualScripts + regularScripts;
 
             for i in lst:
                 self._runScript("{0}/{1}".format(dirname, i));

--- a/src/cygapt/test/test_cygapt.py
+++ b/src/cygapt/test/test_cygapt.py
@@ -127,6 +127,7 @@ class TestCygApt(TestCase):
         cygapt.setDosBash("bash");
         cygapt.setDosLn("ln");
         cygapt.setDosXz('xz');
+        cygapt.setDosDash('dash');
 
         cygapt.setPrefixRoot(self._dir_mtroot[:-1]);
         cygapt.setAbsRoot(self._dir_mtroot);
@@ -353,30 +354,37 @@ class TestCygApt(TestCase):
         self.obj._postInstall();
         self.assertPostInstall();
 
-    def testPostInstallWhenScriptSuccess(self):
-        foo = os.path.join(self._dir_postinstall, "foo.sh");
-        bar = os.path.join(self._dir_postinstall, "bar.sh");
-        self._writeScript(foo, 0);
-        self._writeScript(bar, 0);
+    def testPostInstallWhenScriptSuccessWithShExtension(self):
+        self._assertPostInstallWhenScriptSuccess('.sh');
 
-        self.obj.postinstall();
+    def testPostInstallWhenScriptSuccessWithDashExtension(self):
+        self._assertPostInstallWhenScriptSuccess('.dash');
 
-        self.assertPostInstall();
-        self.assertTrue(os.path.isfile(foo+".done"));
-        self.assertTrue(os.path.isfile(bar+".done"));
+    def testPostInstallWhenScriptSuccessWithBatExtension(self):
+        self._skipIfOutsideCygwinAndWindows();
 
-    def testPostInstallWhenScriptFails(self):
-        foo = os.path.join(self._dir_postinstall, "foo.sh");
-        self._writeScript(foo, 1);
-        bar = os.path.join(self._dir_postinstall, "bar.sh");
-        self._writeScript(bar, 2);
+        self._assertPostInstallWhenScriptSuccess('.bat');
 
-        self.obj.postinstall();
+    def testPostInstallWhenScriptSuccessWithCmdExtension(self):
+        self._skipIfOutsideCygwinAndWindows();
 
-        self.assertTrue(os.path.isfile(foo));
-        self.assertFalse(os.path.isfile(foo+".done"));
-        self.assertTrue(os.path.isfile(bar));
-        self.assertFalse(os.path.isfile(bar+".done"));
+        self._assertPostInstallWhenScriptSuccess('.cmd');
+
+    def testPostInstallWhenScriptFailsWithShExtension(self):
+        self._assertPostInstallWhenScriptFails('.sh');
+
+    def testPostInstallWhenScriptFailsWithDashExtension(self):
+        self._assertPostInstallWhenScriptFails('.dash');
+
+    def testPostInstallWhenScriptFailsWithBatExtension(self):
+        self._skipIfOutsideCygwinAndWindows();
+
+        self._assertPostInstallWhenScriptFails('.bat');
+
+    def testPostInstallWhenScriptFailsWithCmdExtension(self):
+        self._skipIfOutsideCygwinAndWindows();
+
+        self._assertPostInstallWhenScriptFails('.cmd');
 
     def testPostRemoveWhenScriptSuccess(self):
         self._var_packagename = "foo";
@@ -436,24 +444,23 @@ class TestCygApt(TestCase):
         self.assertRemove([self.obj.getPkgName()]);
 
     def testInstall(self):
-        # INSTALL
-        self.obj.install();
-
-        expected = self._var_setupIni.pkg.requires.split(" ");
-        expected.append(self.obj.getPkgName());
-        self.assertInstall(expected);
-        self.assertPostInstall();
+        self._assertInstall('pkg');
 
     def testInstallWithLZMACompression(self):
-        self._var_packagename = self._var_setupIni.pkgxz.name;
-        self._var_files = ["", self._var_packagename];
-        self.obj = self._createCygApt();
+        self._assertInstall('pkgxz');
 
-        # INSTALL
-        self.obj.install();
+    def testInstallWithDashScript(self):
+        self._assertInstall('dashpkg');
 
-        self.assertInstall([self._var_packagename]);
-        self.assertPostInstall();
+    def testInstallWithBatScript(self):
+        self._skipIfOutsideCygwinAndWindows();
+
+        self._assertInstall('batpkg');
+
+    def testInstallWithCmdScript(self):
+        self._skipIfOutsideCygwinAndWindows();
+
+        self._assertInstall('cmdpkg');
 
     def testRemove(self):
         self.testInstall();
@@ -590,7 +597,7 @@ class TestCygApt(TestCase):
 
     def assertPostInstall(self):
         for filename in os.listdir(self._dir_postinstall):
-            if filename[-3:] == ".sh":
+            if os.path.splitext(filename)[1] in ['.sh', '.dash', '.cmd', '.bat'] :
                 self.fail("{0} running fail".format(filename));
 
     def assertRemove(self, pkgname_list):
@@ -632,22 +639,53 @@ class TestCygApt(TestCase):
             for line in contents.splitlines() :
                 self.assertNotEqual(line.split()[0], pkg.name, message);
 
-    def _writeScript(self, path, exitCode=0):
-        """Writes sh script to path.
+    def _assertPostInstallWhenScriptSuccess(self, extension):
+        foo = os.path.join(self._dir_postinstall, "foo"+extension);
+        bar = os.path.join(self._dir_postinstall, "bar"+extension);
+        self._writeScript(foo, 0);
+        self._writeScript(bar, 0);
 
-        @param path:     str     A file to write the sript.
-        @param exitCode: integer The exit code of the script.
-        """
-        directory = os.path.dirname(path);
-        if not os.path.isdir(directory) :
-            os.makedirs(directory);
+        self.obj.postinstall();
 
-        with open(path, 'w') as f :
-            f.write("\n".join([
-                "#!/bin/sh",
-                "exit {0:d};",
-                "",
-            ]).format(exitCode));
+        self.assertPostInstall();
+        self.assertTrue(os.path.isfile(foo+".done"));
+        self.assertTrue(os.path.isfile(bar+".done"));
+
+    def _assertPostInstallWhenScriptFails(self, extension):
+        foo = os.path.join(self._dir_postinstall, "foo"+extension);
+        self._writeScript(foo, 1);
+        bar = os.path.join(self._dir_postinstall, "bar"+extension);
+        self._writeScript(bar, 2);
+
+        self.obj.postinstall();
+
+        self.assertTrue(os.path.isfile(foo));
+        self.assertFalse(os.path.isfile(foo+".done"));
+        self.assertTrue(os.path.isfile(bar));
+        self.assertFalse(os.path.isfile(bar+".done"));
+
+    def _assertInstall(self, packageName):
+        self._var_packagename = packageName;
+        self._var_files = ["", self._var_packagename];
+        self.obj = self._createCygApt();
+
+        # INSTALL
+        self.obj.install();
+
+        expected = list();
+        requires = getattr(self._var_setupIni, packageName).requires;
+        if requires :
+            expected += requires.split(" ");
+        expected.append(packageName);
+        self.assertInstall(expected);
+        self.assertPostInstall();
+
+    def _skipIfOutsideCygwinAndWindows(self):
+        if not (
+            sys.platform.startswith("cygwin")
+            or sys.platform.startswith("win")
+        ) :
+            self.skipTest("requires Cygwin or Windows");
 
 if __name__ == "__main__":
     unittest.main();


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Tests pass?     | yes
| Related tickets | #90
| License         | GNU GPLv3

- [x] executing scripts with `dash`, `bat` and `cmd` extensions.
- [x] perpetual post-install scripts are running on the well order before all others.
